### PR TITLE
ROGER-806:[CLI] Allow roger deploy without git_username

### DIFF
--- a/cli/roger-deploy
+++ b/cli/roger-deploy
@@ -334,8 +334,8 @@ def deployApp(object_list, root, args, config, roger_env, work_dir, config_dir, 
   try:
       git_username = subprocess.check_output("git config user.name", shell=True)
   except subprocess.CalledProcessError as e:
-      print("git config user.name not found. Setting default git_username as roger")
-      git_username = "roger"
+      print("git config user.name not found. Setting default git_username as unknown")
+      git_username = "unknown"
 
   deployMessage = "{0}'s deploy for {1} / {2} / {3} completed in {4} seconds.".format(
     git_username.rstrip(), app, environment, branch, deployTime.total_seconds())


### PR DESCRIPTION
roger deploy used to fail if git_username is not set.

After the changes , it will pass and will use a default git_username as "roger".

The user will be prompted with an message as well.
