### PR TITLE
ROGER-824: [CLI] Enable CI (travis) on roger-mesos-tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+python:
+    - 2.7
+
+install:
+    - pip install pyyaml
+    - pip install Jinja2
+    - pip install requests
+
+script:
+    - export PATH=$PATH:/home/travis/build/seomoz/roger-mesos-tools/bin:/home/travis/build/seomoz/roger-mesos-tools/cli
+    - cd tests
+    - python test_roger_init.py
+    - python test_appconfig.py
+    - python test_roger_build.py
+    - python test_settings.py


### PR DESCRIPTION
1 - Setup .travis.yml for roger-mesos-tools.
2 - Currently only the following tests are added: 
- test_roger_init.py
- test_appconfig.py
- test_roger_build.py
- test_settings.py

The following tests were failing since currently our tests need github access as an user to use:
- roger deploy
- roger build
- roger gitpull
- roger push

Once we modify the tests to use mockito rather than doing actual gitpull , we will add those tests.
