### PR TITLE
ROGER-905:[CLI] Look for config file locally before using env var

### DIFF
--- a/cli/appconfig.py
+++ b/cli/appconfig.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 import os
+import os.path
 import sys
 import json
 import yaml
@@ -17,8 +18,12 @@ class AppConfig:
 
   def getConfig(self, config_dir, config_file):
     config = None
-    with open('{0}/{1}'.format(config_dir, config_file)) as config_file_obj:
-      config = yaml.load(config_file_obj) if config_file.lower().endswith('.yml') else json.load(config_file_obj)
+    if os.path.exists(config_file):
+        with open(config_file) as config_file_obj:
+          config = yaml.load(config_file_obj) if config_file.lower().endswith('.yml') else json.load(config_file_obj)
+    else:
+      with open('{0}/{1}'.format(config_dir, config_file)) as config_file_obj:
+        config = yaml.load(config_file_obj) if config_file.lower().endswith('.yml') else json.load(config_file_obj)
     return config
 
   def getAppData(self, config_dir, config_file, app_name):


### PR DESCRIPTION
Modified code to take config file based on path provided to the command. Following behavior now supported:

1 - Use local config file if present. [ Current working directory contains the config file provided ]
2 - Allow absolute path for config file. [ Eg. roger build collectd /tmp/roger.yml ]
3 - Allow relative path for config file. [ Eg. roger build collectd ../roger.yml ]
4 - If config file not present use path from env var. [ Current default behavior ]
