### PR TITLE
need python yaml

### DIFF
--- a/scripts/provision-vm
+++ b/scripts/provision-vm
@@ -4,7 +4,7 @@ function packages_setup {
   apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D || true
   echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list
   apt-get update
-  apt-get install -y docker-engine=1.8.2-0~trusty nodejs npm python-pip python-dev python3-dev python-pytest
+  apt-get install -y docker-engine=1.8.2-0~trusty nodejs npm python-pip python-dev python3-dev python-pytest python-yaml
   pip install setuptools requests mock mockito slackclient Jinja2 tabulate
 }
 


### PR DESCRIPTION
When I cloned this repo, and ran `scripts/provision-vm`, I tried to `pip install -e .`

I then got the following error in the compilation output:

``` bash
x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/usr/include/python2.7 -c build/temp.linux-x86_64-2.7/check_libyaml.c -o build/temp.linux-x86_64-2.7/check_libyaml.o

build/temp.linux-x86_64-2.7/check_libyaml.c:2:18: fatal error: yaml.h: No such file or directory

 #include <yaml.h>

                  ^

compilation terminated.



libyaml is not found or a compiler error: forcing --without-libyaml
```

I fixed this by installing `python-yaml`.

Maybe others have run into this issue?
