### PR TITLE
ROGER-987:[CLI] Fail deploy when build fails(because of missing Dockerfile

### DIFF
--- a/cli/docker_build.py
+++ b/cli/docker_build.py
@@ -210,10 +210,7 @@ class Docker(object):
             swaparoo = null_swaparoo
 
         with swaparoo():
-            try:
-                dockerUtilsObj.docker_build(image_tag, docker_file)
-            except ValueError:
-                raise
+            dockerUtilsObj.docker_build(image_tag, docker_file)
 
 if __name__ == "__main__":
     dockerObj = Docker()


### PR DESCRIPTION
Earlier deploy used to continue even if docker_build failed , due to missing Dockerfile.

With the changes , we raise an exception if the docker file is missing and stop the deploy.
