### PR TITLE
ROGER-793:[CLI] Read user.name in a better way

### DIFF
--- a/cli/roger_deploy.py
+++ b/cli/roger_deploy.py
@@ -374,16 +374,10 @@ class RogerDeploy(object):
 
         deployTime = datetime.now() - startTime
 
-        try:
-            git_username = subprocess.check_output(
-                "git config user.name", shell=True)
-        except subprocess.CalledProcessError as e:
-            print(
-                "git config user.name not found. Setting default git_username as unknown")
-            git_username = "unknown"
+        username = settingObj.getUser()
 
         deployMessage = "{0}'s deploy for {1} / {2} / {3} completed in {4} seconds.".format(
-            git_username.rstrip(), app, environment, branch, deployTime.total_seconds())
+            username.rstrip(), app, environment, branch, deployTime.total_seconds())
         slack.api_call(deployMessage)
         print(deployMessage)
 


### PR DESCRIPTION
In roger_deploy , the username was being fetched from git config.

Removed the dependency on "git" , now fetching the username from environment variable "ROGER_USER"

**Test:**

Integration Test carried out by using "roger deploy" to deploy sample app on localmesos01. 
