### PR TITLE
Providing app_name to push.

### DIFF
--- a/cli/roger_deploy.py
+++ b/cli/roger_deploy.py
@@ -365,6 +365,7 @@ class RogerDeploy(object):
         args.image_name = image_name
         args.config_file = config_file
         args.env = environment
+        args.app_name = app
         self.rogerPushObject.main(settingObj, appObj, frameworkUtils,
                                   hooksObj, args)
 


### PR DESCRIPTION
This is to fix an error that shows up when `deploy` is called with `-sg -s sp` which is a valid use case.
