### PR TITLE
ROGER-1000:Add act-as-user on framework requests

### DIFF
--- a/cli/chronos.py
+++ b/cli/chronos.py
@@ -26,13 +26,19 @@ class Chronos(Framework):
         chronos_resource = "scheduler/iso8601"
         if 'parents' in json.loads(data):
             chronos_resource = "scheduler/dependency"
+
+        if hasattr(self, "act-as-user"):
+           act_as_user = self.act_as_user
+        else:
+            act_as_user = str(settings.getUser())
+
         print("TRIGGERING CHRONOS FRAMEWORK UPDATE FOR: {}".format(container))
         print("curl -X PUT -H 'Content-type: application/json' --data-binary @{} {}/{}".format(
             file_path, environmentObj['chronos_endpoint'], chronos_resource))
         endpoint = environmentObj['chronos_endpoint']
         deploy_url = "{}/{}".format(endpoint, chronos_resource)
         resp = requests.put(deploy_url, data=data, headers={
-                            'Content-type': 'application/json'})
+                            'Content-type': 'application/json', 'act-as-user': act_as_user})
         chronos_message = "{}".format(resp)
         print(chronos_message)
         return resp

--- a/cli/chronos.py
+++ b/cli/chronos.py
@@ -28,7 +28,7 @@ class Chronos(Framework):
             chronos_resource = "scheduler/dependency"
 
         if hasattr(self, "act-as-user"):
-           act_as_user = self.act_as_user
+            act_as_user = self.act_as_user
         else:
             act_as_user = str(settings.getUser())
 

--- a/cli/marathon.py
+++ b/cli/marathon.py
@@ -46,12 +46,18 @@ class Marathon(Framework):
         data = open(file_path).read()
         appName = json.loads(data)['id']
         self.fetchUserPass(environment)
+
+        if hasattr(self, "act-as-user"):
+           act_as_user = self.act_as_user
+        else:
+            act_as_user = str(settings.getUser())
+
         print("TRIGGERING MARATHON FRAMEWORK UPDATE FOR: {}".format(container))
         resp = ""
         if 'groups' in data:
             resp = requests.put("{}/v2/groups/{}".format(environmentObj['marathon_endpoint'], appName),
                                 data=data,
-                                headers={'Content-type': 'application/json'}, auth=(self.user, self.passw))
+                                headers={'Content-type': 'application/json', 'act-as-user': act_as_user}, auth=(self.user, self.passw))
             print("curl -X PUT -H 'Content-type: application/json' --data-binary @{} {}/v2/groups/{}".format(
                 file_path, environmentObj['marathon_endpoint'], appName))
             print (
@@ -60,7 +66,7 @@ class Marathon(Framework):
             endpoint = environmentObj['marathon_endpoint']
             deploy_url = "{}/v2/apps/{}".format(endpoint, appName)
             resp = requests.put(deploy_url, data=data, headers={
-                                'Content-type': 'application/json'}, auth=(self.user, self.passw))
+                                'Content-type': 'application/json', 'act-as-user': act_as_user}, auth=(self.user, self.passw))
             print("curl -X PUT -H 'Content-type: application/json' --data-binary @{} {}/v2/apps/{}".format(
                 file_path, environmentObj['marathon_endpoint'], appName))
             print (
@@ -96,7 +102,7 @@ class Marathon(Framework):
                         if 'TCP_PORTS' in app['env']:
                             tcp_ports_value = app['env']['TCP_PORTS']
                             tcp_port_list = json.loads(tcp_ports_value).keys()
- 
+
                         if 'ENABLE_AFFINITY' in app['env'] and app['env']['ENABLE_AFFINITY'] != "":
                             enable_affinity = True
 

--- a/cli/roger_push.py
+++ b/cli/roger_push.py
@@ -347,6 +347,9 @@ class RogerPush(object):
             else:
                 # push to roger framework
 
+                if 'owner' in config:
+                    frameworkObj.act_as_user = config['act-as-user']
+
                 for container in data_containers:
                     try:
                         function_execution_start_time = datetime.now()


### PR DESCRIPTION
Now the user will be able to use an "owner" tag in the config file , which will be sent as "act-as-user" header from the roger tools. ( roger push to be specific ). This header will be forwarded by "nginx" to "aaad" daemon , which will then be used for authorization in aaad.

**Test:**

1 - Send a sample "act-as-user" header ("moz" ) , from roger-push , verified that it is forwarded by nginx and aaad gets this header.

The test was carried out on the "local" single node setup. 

@amitbose327 Please review
