### PR TITLE
Modified task_id to exclude /

### DIFF
--- a/cli/roger_push.py
+++ b/cli/roger_push.py
@@ -393,7 +393,7 @@ class RogerPush(object):
                                 resp, task_id = frameworkObj.put(
                                     config_file_path, environmentObj, container_name, environment)
 
-                                self.task_id = task_id
+                                self.task_id = self.utils.modify_task_id(task_id)
 
                                 if hasattr(resp, "status_code"):
                                     status_code = resp.status_code

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -72,3 +72,9 @@ class Utils:
         statsd_message_list = []
         statsd_message_list = deepcopy(modified_message_list)
         return statsd_message_list
+
+    def modify_task_id(self, task_id):
+        if task_id[0] == '/':
+            task_id = task_id[1:]
+        task_id = task_id.replace("/", "_")
+        return task_id

--- a/tests/test_roger_push.py
+++ b/tests/test_roger_push.py
@@ -694,6 +694,7 @@ class TestPush(unittest.TestCase):
         when(roger_push.utils).getStatsClient().thenReturn(sc)
         when(roger_push.utils).get_identifier(any(), any(), any()).thenReturn(any())
         when(roger_push.utils).extract_app_name(any()).thenReturn("test")
+        when(roger_push.utils).modify_task_id(any()).thenReturn(any())
 
         when(frameworkUtils).getFramework(data).thenReturn(marathon)
         when(settings).getComponentsDir().thenReturn(
@@ -785,6 +786,7 @@ class TestPush(unittest.TestCase):
         when(roger_push.utils).getStatsClient().thenReturn(sc)
         when(roger_push.utils).get_identifier(any(), any(), any()).thenReturn(any())
         when(roger_push.utils).extract_app_name(any()).thenReturn("test")
+        when(roger_push.utils).modify_task_id(any()).thenReturn(any())
 
         frameworkUtils = mock(FrameworkUtils)
         when(frameworkUtils).getFramework(data).thenReturn(marathon)


### PR DESCRIPTION
Made changes to "task_id". Now it will not include "/" while logging the values to tools_db. This will help us in using "task_id" as template in Grafana chart. [ RogerOS_Container_Metrics ]