### PR TITLE
Fix Ruby Swaparoo private repo hack for new bundler versions

### DIFF
--- a/cli/docker_build.py
+++ b/cli/docker_build.py
@@ -90,7 +90,7 @@ def download_private_repos(projects, update_id=None):
 # origin/ branch, although if we only use this script, the branch never
 # should exist anyway.
 GEMFILE_BRANCH_HACK = '''
-$gem2 = method(:gem)
+$gem2 = method(:gem) rescue method(:_gem)
 def gem(*args)
   gem, ver, opts = args
   opts = ver  if !opts && ver.is_a?(Hash)


### PR DESCRIPTION
Newer bundler versions were giving an error on `method(:gem)`. It seems
to be now named `_gem` in newer versions (not sure how the 'gem' method
is still working, possibly that is now a built-in which smartly defers
to bundler?) Anyway, this fixes it.

There is at least one arguably better way to do private repos in docker
now (I prefer using a container to forward SSH creds)