### PR TITLE
Add docker-wrap.sh from seomoz/docker-sshagent-socket

### DIFF
--- a/bin/docker-forward-ssh-agent
+++ b/bin/docker-forward-ssh-agent
@@ -1,0 +1,32 @@
+# Shares SSH agent credentials, so within a "docker build", the building container
+# can access private Github repos. This script brings up the auxiliary container which
+# shares the credentials, then stops it when the command you want to run is done.
+#
+# Usage: "docker-forward-ssh-agent docker build -t foo .", "docker-forward-ssh-agent docker-compose build",
+#        "docker-forward-ssh-agent roger deploy -e stage myproject myconfig.yml", etc.
+#
+# Note: should be used with extreme care on shared computers! You could be exposing your
+# credentials for all on the local system to share.
+#
+# Also, due to the hard-coding of the container name and ports, only one of this script
+# can be running at one time.
+#
+# Uses seomoz/sshagent-socket (forked from aidanhs/sshagent-socket) to forward
+# SSH agent to make it available inside a container running `docker build`
+#
+# See https://github.com/seomoz/docker-sshagent-socket/ for more info on how to
+# configure your Docker file to work with this.
+
+if ! docker run -d -p $(ifconfig|grep -1 docker0|tail -n 1|cut -d: -f2|awk '{print $1}'):5522:5522 -v $(dirname $SSH_AUTH_SOCK):/s$(dirname $SSH_AUTH_SOCK) --name=dsshagent seomoz/sshagent-socket $SSH_AUTH_SOCK
+then
+  echo "ERROR -- couldnt start dsshagent"
+  exit 1
+fi
+
+"$@"
+
+exitcode=$?
+
+docker rm -f dsshagent
+
+exit $exitcode


### PR DESCRIPTION
To allow easy deployment of projects which need private repo access. Unlike my previous ruby hack, this should for any project of any language which has a file with dependencies and a command to fetch, i.e. something similar to `Gemfile`, `package.json`, `requirements.txt`, `mix.exs` etc.

Can be ran like `docker-forward-ssh-agent roger deploy -e stage roskilde kwe.yml`

Suggestions for better name for the script welcome.

In the future it might be nice to add a flag to the roger command so we
could just do something like

`roger deploy -A -e stage roskilde kwe.yml`

See https://github.com/seomoz/docker-sshagent-socket/

See https://github.com/seomoz/roskilde/pull/12/files for an example
  