### PR TITLE
Use environment variable after parsing from args

### DIFF
--- a/cli/roger_gitpull.py
+++ b/cli/roger_gitpull.py
@@ -94,7 +94,7 @@ class RogerGitPull(object):
                         raise
 
             hookname = "pre_gitpull"
-            exit_code = hooksObj.run_hook(hookname, data, args.directory, args.environment, settingObj.getUser())
+            exit_code = hooksObj.run_hook(hookname, data, args.directory, environment, settingObj.getUser())
             if exit_code != 0:
                 raise ValueError("{} hook failed.".format(hookname))
 
@@ -112,7 +112,7 @@ class RogerGitPull(object):
                 raise ValueError("Gitpull failed.")
 
             hookname = "post_gitpull"
-            exit_code = hooksObj.run_hook(hookname, data, args.directory, args.environment, settingObj.getUser())
+            exit_code = hooksObj.run_hook(hookname, data, args.directory, environment, settingObj.getUser())
             if exit_code != 0:
                 raise ValueError("{} hook failed.".format(hookname))
         except (Exception) as e:


### PR DESCRIPTION
Running the gitpull procedure appears to define a local variable with a
default value that is meant to be overridden in args. In a scenario
where the environment is not provided by the arguments, the procedures
attempt to run with the `args.environment` value, not the local
`environment` variable.

This ends up crashing the program if the environment is not part of the
args.

Fixes #163